### PR TITLE
Don't show category list if only one is available

### DIFF
--- a/classes/class-subscribe.php
+++ b/classes/class-subscribe.php
@@ -14,7 +14,6 @@ if( class_exists( 'STC_Subscribe' ) ) {
   $stc_subscribe = new STC_Subscribe();
 }
 
-
   class STC_Subscribe {
 
     protected static $instance = null;
@@ -782,6 +781,7 @@ if( class_exists( 'STC_Subscribe' ) ) {
           </div>
 
           <div class="stc-categories"<?php echo $post_stc_unsubscribe == 1 ? ' style="display:none;"' : NULL; ?>>
+            <?php if(! empty( $cats ) && count ($cats) > 1 ) : ?>
             <h3><?php _e('Categories', STC_TEXTDOMAIN ); ?></h3>
             <?php if( $this->show_all_categories === true ) : ?>
             <div class="checkbox">
@@ -792,7 +792,7 @@ if( class_exists( 'STC_Subscribe' ) ) {
             </div>
             <?php endif; ?>
             <div class="stc-categories-checkboxes">
-            <?php if(! empty( $cats ) ) : ?>
+            <?php if(count($cats)>1 ) : ?>
     				<?php foreach ($cats as $cat ) : ?>
             <div class="checkbox">
       				<label>
@@ -801,9 +801,12 @@ if( class_exists( 'STC_Subscribe' ) ) {
       				</label>
             </div>
   				  <?php endforeach; ?>
+          <?php else: ?>
+              <input type="hidden" name="stc_categories[]" value="<?php echo $cat[0]->cat_ID ?>">
           <?php endif; ?>
           </div><!-- .stc-categories-checkboxes -->
           </div><!-- .stc-categories -->
+          <?php endif; ?>
 
   				<input type="hidden" name="action" value="stc_subscribe_me" />
   				<?php wp_nonce_field( 'wp_nonce_stc', 'stc_nonce', true, true ); ?>

--- a/classes/class-subscribe.php
+++ b/classes/class-subscribe.php
@@ -804,7 +804,7 @@ if( class_exists( 'STC_Subscribe' ) ) {
                     </div>
                   <?php endforeach; ?>
                 <?php else: ?>
-                  <input type="hidden" name="stc_categories[]" value="<?php echo $cat[0]->cat_ID ?>">
+                  <input type="hidden" name="stc_categories[]" value="<?php echo $cats[0]->cat_ID ?>">
                 <?php endif; ?>
               </div><!-- .stc-categories-checkboxes -->
             <?php endif; ?>

--- a/classes/class-subscribe.php
+++ b/classes/class-subscribe.php
@@ -794,19 +794,21 @@ if( class_exists( 'STC_Subscribe' ) ) {
                 <?php endif; ?>
             <?php endif; ?>
             <div class="stc-categories-checkboxes">
-            <?php if(count($cats)>1 ) : ?>
-    	      <?php foreach ($cats as $cat ) : ?>
-                <div class="checkbox">
-      		  <label>
-      		    <input type="checkbox" name="stc_categories[]" value="<?php echo $cat->cat_ID ?>">
-      		    <?php echo $cat->cat_name; ?>
-      		  </label>
-                </div>
-              <?php endforeach; ?>
-            <?php else: ?>
-              <input type="hidden" name="stc_categories[]" value="<?php echo $cat[0]->cat_ID ?>">
+            <?php if(! empty( $cats ) ) : ?>
+              <?php if(count($cats)>1 ) : ?>
+    	        <?php foreach ($cats as $cat ) : ?>
+                  <div class="checkbox">
+      		    <label>
+      		      <input type="checkbox" name="stc_categories[]" value="<?php echo $cat->cat_ID ?>">
+      		      <?php echo $cat->cat_name; ?>
+      		    </label>
+                  </div>
+                <?php endforeach; ?>
+              <?php else: ?>
+                <input type="hidden" name="stc_categories[]" value="<?php echo $cat[0]->cat_ID ?>">
+              <?php endif; ?>
             <?php endif; ?>
-          </div><!-- .stc-categories-checkboxes -->
+            </div><!-- .stc-categories-checkboxes -->
           </div><!-- .stc-categories -->
         <?php endif; ?>
 

--- a/classes/class-subscribe.php
+++ b/classes/class-subscribe.php
@@ -782,7 +782,7 @@ if( class_exists( 'STC_Subscribe' ) ) {
 
           <div class="stc-categories"<?php echo $post_stc_unsubscribe == 1 ? ' style="display:none;"' : NULL; ?>>
             <?php if(! empty( $cats )) :?>
-              <?php if count ($cats) > 1 ) : ?>
+              <?php if (count ($cats) > 1 ) : ?>
                 <h3><?php _e('Categories', STC_TEXTDOMAIN ); ?></h3>
                 <?php if( $this->show_all_categories === true ) : ?>
                   <div class="checkbox">

--- a/classes/class-subscribe.php
+++ b/classes/class-subscribe.php
@@ -781,32 +781,34 @@ if( class_exists( 'STC_Subscribe' ) ) {
           </div>
 
           <div class="stc-categories"<?php echo $post_stc_unsubscribe == 1 ? ' style="display:none;"' : NULL; ?>>
-            <?php if(! empty( $cats ) && count ($cats) > 1 ) : ?>
-            <h3><?php _e('Categories', STC_TEXTDOMAIN ); ?></h3>
-            <?php if( $this->show_all_categories === true ) : ?>
-            <div class="checkbox">
-              <label>
-                <input type="checkbox" id="stc-all-categories" name="stc_all_categories" value="1">
-                <?php _e('All categories', STC_TEXTDOMAIN ); ?>
-              </label>
-            </div>
+            <?php if(! empty( $cats )) :?>
+              <?php if count ($cats) > 1 ) : ?>
+                <h3><?php _e('Categories', STC_TEXTDOMAIN ); ?></h3>
+                <?php if( $this->show_all_categories === true ) : ?>
+                  <div class="checkbox">
+                    <label>
+                      <input type="checkbox" id="stc-all-categories" name="stc_all_categories" value="1">
+                      <?php _e('All categories', STC_TEXTDOMAIN ); ?>
+                    </label>
+                  </div>
+                <?php endif; ?>
             <?php endif; ?>
             <div class="stc-categories-checkboxes">
             <?php if(count($cats)>1 ) : ?>
-    				<?php foreach ($cats as $cat ) : ?>
-            <div class="checkbox">
-      				<label>
-      					<input type="checkbox" name="stc_categories[]" value="<?php echo $cat->cat_ID ?>">
-      					<?php echo $cat->cat_name; ?>
-      				</label>
-            </div>
-  				  <?php endforeach; ?>
-          <?php else: ?>
+    	      <?php foreach ($cats as $cat ) : ?>
+                <div class="checkbox">
+      		  <label>
+      		    <input type="checkbox" name="stc_categories[]" value="<?php echo $cat->cat_ID ?>">
+      		    <?php echo $cat->cat_name; ?>
+      		  </label>
+                </div>
+              <?php endforeach; ?>
+            <?php else: ?>
               <input type="hidden" name="stc_categories[]" value="<?php echo $cat[0]->cat_ID ?>">
-          <?php endif; ?>
+            <?php endif; ?>
           </div><!-- .stc-categories-checkboxes -->
           </div><!-- .stc-categories -->
-          <?php endif; ?>
+        <?php endif; ?>
 
   				<input type="hidden" name="action" value="stc_subscribe_me" />
   				<?php wp_nonce_field( 'wp_nonce_stc', 'stc_nonce', true, true ); ?>

--- a/classes/class-subscribe.php
+++ b/classes/class-subscribe.php
@@ -792,25 +792,24 @@ if( class_exists( 'STC_Subscribe' ) ) {
                     </label>
                   </div>
                 <?php endif; ?>
-            <?php endif; ?>
-            <div class="stc-categories-checkboxes">
-            <?php if(! empty( $cats ) ) : ?>
-              <?php if(count($cats)>1 ) : ?>
-    	        <?php foreach ($cats as $cat ) : ?>
-                  <div class="checkbox">
-      		    <label>
-      		      <input type="checkbox" name="stc_categories[]" value="<?php echo $cat->cat_ID ?>">
-      		      <?php echo $cat->cat_name; ?>
-      		    </label>
-                  </div>
-                <?php endforeach; ?>
-              <?php else: ?>
-                <input type="hidden" name="stc_categories[]" value="<?php echo $cat[0]->cat_ID ?>">
               <?php endif; ?>
+              <div class="stc-categories-checkboxes">
+                <?php if(count($cats)>1 ) : ?>
+    	          <?php foreach ($cats as $cat ) : ?>
+                    <div class="checkbox">
+      		      <label>
+      		        <input type="checkbox" name="stc_categories[]" value="<?php echo $cat->cat_ID ?>">
+      		        <?php echo $cat->cat_name; ?>
+      		      </label>
+                    </div>
+                  <?php endforeach; ?>
+                <?php else: ?>
+                  <input type="hidden" name="stc_categories[]" value="<?php echo $cat[0]->cat_ID ?>">
+                <?php endif; ?>
+              </div><!-- .stc-categories-checkboxes -->
             <?php endif; ?>
-            </div><!-- .stc-categories-checkboxes -->
           </div><!-- .stc-categories -->
-        <?php endif; ?>
+
 
   				<input type="hidden" name="action" value="stc_subscribe_me" />
   				<?php wp_nonce_field( 'wp_nonce_stc', 'stc_nonce', true, true ); ?>


### PR DESCRIPTION
Change made for not showing category list if there's no categories available.
If there's only one category available, don't show it and mark it by default.
